### PR TITLE
Add port to URI if set and provide ability to create relative URI with ViewHelper Uri/Styleguide

### DIFF
--- a/Classes/Service/StyleguideConfigurationManager.php
+++ b/Classes/Service/StyleguideConfigurationManager.php
@@ -251,10 +251,13 @@ class StyleguideConfigurationManager
 
         $baseUrl = static::getCurrentSite()->getBase();
         $modified = filemtime($path);
-        return $baseUrl->withPath(
-            $baseUrl->getPath() .
-            PathUtility::stripPathSitePrefix(GeneralUtility::getFileAbsFileName($path))
-        )->withQuery('?' . $modified);
+        return $baseUrl
+            ->withPath(
+                $baseUrl->getPath() .
+                PathUtility::stripPathSitePrefix(GeneralUtility::getFileAbsFileName($path))
+            )
+            ->withQuery('?' . $modified)
+            ->withPort(GeneralUtility::getIndpEnv('TYPO3_PORT') ?: null);
     }
 
     /**

--- a/Classes/ViewHelpers/Uri/StyleguideViewHelper.php
+++ b/Classes/ViewHelpers/Uri/StyleguideViewHelper.php
@@ -20,6 +20,7 @@ class StyleguideViewHelper extends AbstractViewHelper
         $this->registerArgument('action', 'string', 'Action name', true);
         $this->registerArgument('arguments', 'array', 'Action arguments', false, []);
         $this->registerArgument('section', 'string', 'the anchor to be added to the URI', false, '');
+        $this->registerArgument('relative', 'bool', 'generate a relative path', false, true);
     }
 
     /**
@@ -38,9 +39,19 @@ class StyleguideViewHelper extends AbstractViewHelper
         $prefix = GeneralUtility::makeInstance(ExtensionConfiguration::class)
             ->get('fluid_styleguide', 'uriPrefix');
         $prefix = rtrim($prefix, '/') . '/';
-        // TODO generate relative urls
 
         $baseUrl = static::getCurrentSite()->getBase();
+
+        // reset scheme and host to return a relative path
+        if ($arguments['relative'] === true) {
+            return $baseUrl
+                ->withScheme('')
+                ->withHost('')
+                ->withPath($prefix . $arguments['action'])
+                ->withQuery(http_build_query($arguments['arguments']))
+                ->withFragment($arguments['section']);
+        }
+
         return $baseUrl
             ->withPath($prefix . $arguments['action'])
             ->withQuery(http_build_query($arguments['arguments']))

--- a/Classes/ViewHelpers/Uri/StyleguideViewHelper.php
+++ b/Classes/ViewHelpers/Uri/StyleguideViewHelper.php
@@ -39,10 +39,13 @@ class StyleguideViewHelper extends AbstractViewHelper
             ->get('fluid_styleguide', 'uriPrefix');
         $prefix = rtrim($prefix, '/') . '/';
         // TODO generate relative urls
-        return static::getCurrentSite()->getBase()
+
+        $baseUrl = static::getCurrentSite()->getBase();
+        return $baseUrl
             ->withPath($prefix . $arguments['action'])
             ->withQuery(http_build_query($arguments['arguments']))
-            ->withFragment($arguments['section']);
+            ->withFragment($arguments['section'])
+            ->withPort(GeneralUtility::getIndpEnv('TYPO3_PORT') ?: null);
     }
 
     /**


### PR DESCRIPTION
With this change the URLs for assets generated by the class
Sitegeist\FluidStyleguide\Service\StyleguideConfigurationManager include
a port if it is set. Also take the port into account for the URI
styleguide ViewHelper.

Furthermore the ViewHelper supports to generate a relative URL
which is the default behavior and can be controlled by the new
argument `relative`.