### PR TITLE
Allow Nested Fluid Rendering in Fixtures

### DIFF
--- a/Classes/ViewHelpers/Component/ExampleViewHelper.php
+++ b/Classes/ViewHelpers/Component/ExampleViewHelper.php
@@ -167,19 +167,21 @@ class ExampleViewHelper extends AbstractViewHelper
     /**
      * Renders inline fluid code in a fixture array that will be provided as example data to a component
      *
-     * @param array $data
+     * @param mixed $data
      * @param RenderingContextInterface $renderingContext
-     * @return void
+     * @return mixed
      */
-    public static function renderFluidInExampleData(array $data, RenderingContextInterface $renderingContext)
+    public static function renderFluidInExampleData($data, RenderingContextInterface $renderingContext)
     {
-        return array_map(function ($value) use ($renderingContext) {
-            if (is_string($value)) {
-                return $renderingContext->getTemplateParser()->parse($value)->render($renderingContext);
-            } else {
-                return $value;
-            }
-        }, $data);
+        if (is_string($data)) {
+            return $renderingContext->getTemplateParser()->parse($data)->render($renderingContext);
+        } elseif (is_array($data)) {
+            return array_map(function ($value) use ($renderingContext) {
+                return self::renderFluidInExampleData($value, $renderingContext);
+            }, $data);
+        } else {
+            return $data;
+        }
     }
 
     /**


### PR DESCRIPTION
This PR allows for rendering nested fluid in fixtures.

According to [this](https://github.com/sitegeist/fluid-styleguide/blob/master/Documentation/BuildingComponents.md) it is possible to have components rendered in the fixture example data like this:
```
{
    "default": {
        "actions": "<my:atom.button>Primary Button</my:atom.button><my:atom.button isSecondary='1'>Secondary Button</my:atom.button>"
    }
}
```

But sadly it is currently not possible to something like the following:

**Components/Container/Container.html**
```
<fc:component>
    <fc:param name="columns" type="string" optional="1" />

    <fc:renderer>
        <div class="container">
            <f:if condition="{columns}">
                <div class="row">
                    <f:for each="{columns}" as="column">
                        <div class="col">
                            {column -> f:format.raw()}
                        </div>
                    </f:for>
                </div>
            </f:if>
        </div>
    </fc:renderer>
</fc:component>
```

**Components/Container/Container.fixture.json**
```
{
  "default": {
    "columns": [
      "<uosComp:container.column title='Title 1!'>This is some text content</uosComp:container.column>",
      "<uosComp:container.column title='Title 2!'>This is more text content</uosComp:container.column>"
    ]
  }
}
```

**Components/Container/Container/Column.html**
```
<fc:component>
    <fc:param name="title" type="string" optional="1" />

    <fc:renderer>
        <h5>{title}</h5>
        <p>{content}</p>
    </fc:renderer>
</fc:component>
```

This will render
```
<div class="container">
    <div class="row">
        <div class="col">
            <uosComp:container.column title='Title 1!'>This is some text content</uosComp:container.column>
        </div> 
        <div class="col"> 
            <uosComp:container.column title='Title 2!'>This is more text content</uosComp:container.column>
        </div>
    </div>
</div>
```

But it would be nice if it rendered
```
<div class="container">
    <div class="row">
        <div class="col">
            <h5>Title 1!</h5>
            <p>This is some text content</p> 
        </div> 
        <div class="col"> 
            <h5>Title 2!</h5>
            <p>This is more text content</p> 
        </div>
    </div>
</div>
```


This example represents any components where you want to pass nested rendered sub-components, not as a single string parameter. Multiple use cases come to mind, like an accordion, a carousel, this column container, a footer with sub-components. Basically any components that need to render markup around the sub-components.


This PR makes the ExampleViewHelper::renderFluidInExampleData fully recursive. It used to only render the fluid contained in strings of the first level.