### PR TITLE
[BUGFIX] Remove setting of application type for TYPO3 < 11

### DIFF
--- a/Classes/Middleware/StyleguideRouter.php
+++ b/Classes/Middleware/StyleguideRouter.php
@@ -178,10 +178,12 @@ class StyleguideRouter implements MiddlewareInterface
         string $actionName
     ): StandaloneView {
         $view = $this->container->get(StandaloneView::class);
-        $request = $view->getRenderingContext()->getControllerContext()->getRequest()
-            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
-        $request->setControllerExtensionName($extensionName);
-        $view->getRenderingContext()->getControllerContext()->setRequest($request);
+        if (version_compare(TYPO3_version, '11.0', '>=')) {
+            $request = $view->getRenderingContext()->getControllerContext()->getRequest()
+                ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
+            $request->setControllerExtensionName($extensionName);
+            $view->getRenderingContext()->getControllerContext()->setRequest($request);
+        }
         $view->getRenderingContext()->setControllerName($controllerName);
         $view->getRenderingContext()->setControllerAction($actionName);
         return $view;


### PR DESCRIPTION
In 10.4 this throws the following error:
`Call to undefined method TYPO3\CMS\Extbase\Mvc\Web\Request::withAttribute()`

As it seems to work without the application type, i would suggest to only set it for v11