### PR TITLE
Extract creation of Components to a factory

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -8,6 +8,7 @@
         ".Build",
         ".git",
         ".DS_Store",
+        ".idea",
         "Resources/Private/Php/",
         "node_modules",
         "var/"

--- a/Classes/Factory/Component/ComponentFactory.php
+++ b/Classes/Factory/Component/ComponentFactory.php
@@ -1,14 +1,4 @@
 <?php declare(strict_types=1);
-/**
- * LICENSE
- *
- * This software and its source code is protected by copyright law (Sec. 69a ff. UrhG).
- * It is not allowed to make any kinds of modifications, nor must it be copied,
- * or published without explicit permission. Misuse will lead to persecution.
- *
- * @copyright  2022 infomax websolutions GmbH
- * @link       http://www.infomax-it.de
- */
 
 namespace Sitegeist\FluidStyleguide\Factory\Component;
 

--- a/Classes/Factory/Component/ComponentFactory.php
+++ b/Classes/Factory/Component/ComponentFactory.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+/**
+ * LICENSE
+ *
+ * This software and its source code is protected by copyright law (Sec. 69a ff. UrhG).
+ * It is not allowed to make any kinds of modifications, nor must it be copied,
+ * or published without explicit permission. Misuse will lead to persecution.
+ *
+ * @copyright  2022 infomax websolutions GmbH
+ * @link       http://www.infomax-it.de
+ */
+
+namespace Sitegeist\FluidStyleguide\Factory\Component;
+
+use Sitegeist\FluidStyleguide\Domain\Model\Component;
+use Sitegeist\FluidStyleguide\Domain\Model\ComponentLocation;
+use Sitegeist\FluidStyleguide\Domain\Model\ComponentName;
+
+/**
+ * Simple factory that just creates a new instance of Component and passes the name and location to the constructor.
+ *
+ * Replace this factory in the DI configuration if you need different components
+ */
+final class ComponentFactory implements ComponentFactoryInterface
+{
+
+    public function build(ComponentName $componentName, ComponentLocation $componentLocation) : Component
+    {
+        return new Component($componentName, $componentLocation);
+    }
+}

--- a/Classes/Factory/Component/ComponentFactoryInterface.php
+++ b/Classes/Factory/Component/ComponentFactoryInterface.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+/**
+ * LICENSE
+ *
+ * This software and its source code is protected by copyright law (Sec. 69a ff. UrhG).
+ * It is not allowed to make any kinds of modifications, nor must it be copied,
+ * or published without explicit permission. Misuse will lead to persecution.
+ *
+ * @copyright  2022 infomax websolutions GmbH
+ * @link       http://www.infomax-it.de
+ */
+
+namespace Sitegeist\FluidStyleguide\Factory\Component;
+
+use Sitegeist\FluidStyleguide\Domain\Model\Component;
+use Sitegeist\FluidStyleguide\Domain\Model\ComponentLocation;
+use Sitegeist\FluidStyleguide\Domain\Model\ComponentName;
+
+/**
+ * Interface to create Components on the fly  so we can create custom components. The factory can be swapped using the DI container
+ */
+interface ComponentFactoryInterface
+{
+
+    /**
+     * Builds the component and passes the component name and component location on.
+     *
+     * @param ComponentName $componentName
+     * @param ComponentLocation $componentLocation
+     * @return Component
+     */
+    public function build(ComponentName $componentName, ComponentLocation $componentLocation) : Component;
+}

--- a/Classes/Factory/Component/ComponentFactoryInterface.php
+++ b/Classes/Factory/Component/ComponentFactoryInterface.php
@@ -1,14 +1,4 @@
 <?php declare(strict_types=1);
-/**
- * LICENSE
- *
- * This software and its source code is protected by copyright law (Sec. 69a ff. UrhG).
- * It is not allowed to make any kinds of modifications, nor must it be copied,
- * or published without explicit permission. Misuse will lead to persecution.
- *
- * @copyright  2022 infomax websolutions GmbH
- * @link       http://www.infomax-it.de
- */
 
 namespace Sitegeist\FluidStyleguide\Factory\Component;
 


### PR DESCRIPTION
We want to do some project specific modifications to the fixtures after they are loaded. To do this we need to implement custom component classes.

Right now they are created in the ComponentRepository. This PR extracts the creation to Factory Interface with the current behavior as default. This way the factory can be replaced using the DI container configuration and custom components can be used easily.