### PR TITLE
[FEATURE] renderFluid in Array Params

### DIFF
--- a/Classes/ViewHelpers/Component/ExampleViewHelper.php
+++ b/Classes/ViewHelpers/Component/ExampleViewHelper.php
@@ -176,6 +176,11 @@ class ExampleViewHelper extends AbstractViewHelper
         return array_map(function ($value) use ($renderingContext) {
             if (is_string($value)) {
                 return $renderingContext->getTemplateParser()->parse($value)->render($renderingContext);
+            } else if (is_array($value)) {
+                foreach ($value as $key => $innerValue) {
+                    $value[$key] = static::renderFluidInExampleData($innerValue,$renderingContext);
+                }
+                return $value;
             } else {
                 return $value;
             }

--- a/Classes/ViewHelpers/Component/ExampleViewHelper.php
+++ b/Classes/ViewHelpers/Component/ExampleViewHelper.php
@@ -177,10 +177,7 @@ class ExampleViewHelper extends AbstractViewHelper
             if (is_string($value)) {
                 return $renderingContext->getTemplateParser()->parse($value)->render($renderingContext);
             } else if (is_array($value)) {
-                foreach ($value as $key => $innerValue) {
-                    $value[$key] = static::renderFluidInExampleData($innerValue,$renderingContext);
-                }
-                return $value;
+                return static::renderFluidInExampleData($value,$renderingContext);
             } else {
                 return $value;
             }


### PR DESCRIPTION
if fluid parameters are in an array, they will now be rendered in the same way as in a simple string parameter