### PR TITLE
[BUGFIX] Wrong path to default configuration file

### DIFF
--- a/Documentation/ConfigurationReference.md
+++ b/Documentation/ConfigurationReference.md
@@ -4,7 +4,7 @@ Fluid Styleguide can be configured in various ways by creating a YAML configurat
 
 **Configuration/Yaml/FluidStyleguide.yaml**
 
-Each extension can add its own configuration to the styleguide, all available files will be picked up automatically and merged with the [default configuration file](./Configuration/Yaml/FluidStyleguide.yaml).
+Each extension can add its own configuration to the styleguide, all available files will be picked up automatically and merged with the [default configuration file](../Configuration/Yaml/FluidStyleguide.yaml).
 
 ## Adding frontend assets
 


### PR DESCRIPTION
Dead link fixed at the very beginning of `ConfigurationReference.md`