### PR TITLE
[BUGFIX] initialize GLOBALS['LANG']

### DIFF
--- a/Classes/Middleware/StyleguideRouter.php
+++ b/Classes/Middleware/StyleguideRouter.php
@@ -15,6 +15,7 @@ use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -151,6 +152,10 @@ class StyleguideRouter implements MiddlewareInterface
                 ));
                 $GLOBALS['TYPO3_REQUEST'] = $request;
             }
+        }
+
+        if (!isset($GLOBALS['LANG'])) {
+            $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->createFromSiteLanguage($request->getAttribute('language'));
         }
 
         // Create view


### PR DESCRIPTION
prevents: `PHP Warning: Undefined global variable $LANG in /var/www/html/private/typo3/sysext/extbase/Classes/Utility/LocalizationUtility.php line 324`
and `TYPO3\CMS\Extbase\Utility\LocalizationUtility::getLanguageService(): Return value must be of type TYPO3\CMS\Core\Localization\LanguageService, null returned`

I will close https://github.com/sitegeist/fluid-components/pull/120 in favor of this patch. Since the error only occurs in the style_fuide