### PR TITLE
FrontendTypoScript: Fixed missing setup array

### DIFF
--- a/Classes/Middleware/StyleguideRouter.php
+++ b/Classes/Middleware/StyleguideRouter.php
@@ -149,6 +149,7 @@ class StyleguideRouter implements MiddlewareInterface
         $plainFrontendTypoScript = new FrontendTypoScript(new RootNode(), [], [], []);
         if ((new Typo3Version())->getMajorVersion() >= 13) {
             $plainFrontendTypoScript->setConfigArray([]);
+            $plainFrontendTypoScript->setSetupArray([]);
         }
 
         $request = $request->withAttribute('frontend.typoscript', $plainFrontendTypoScript);


### PR DESCRIPTION
The setup array is needed in case of using the translation viewhelper

Fixes: 
https://github.com/sitegeist/fluid-styleguide/issues/121#issuecomment-2464537121 
Setup array has not been initialized. This happens in cached Frontend scope where full TypoScript is not needed by the system.