### PR TITLE
FIX: Implicitly marking parameter as nullable is deprecated

### DIFF
--- a/Classes/ViewHelpers/Component/ExampleViewHelper.php
+++ b/Classes/ViewHelpers/Component/ExampleViewHelper.php
@@ -180,7 +180,7 @@ class ExampleViewHelper extends AbstractViewHelper
     public static function applyComponentContext(
         string $componentMarkup,
         string $context,
-        RenderingContextInterface $renderingContext = null,
+        ?RenderingContextInterface $renderingContext = null,
         array $data = []
     ): string {
         // Check if the context should be fetched from a file


### PR DESCRIPTION
... the explicit nullable type must be used